### PR TITLE
Feat: getAlgo method

### DIFF
--- a/src/Balancing/Balancing.php
+++ b/src/Balancing/Balancing.php
@@ -21,6 +21,11 @@ class Balancing
         $this->algo = $algo;
     }
 
+    public function getAlgo(): Algorithm
+    {
+        return $this->algo;
+    }
+
     public function addOption(Option $option): self
     {
         $this->options[] = $option;

--- a/tests/Balancing/BalancingTest.php
+++ b/tests/Balancing/BalancingTest.php
@@ -16,6 +16,8 @@ class BalancingTest extends TestCase
     {
         $balancing = new Balancing(new RoundRobin(-1));
 
+        $this->assertInstanceOf(RoundRobin::class, $balancing->getAlgo());
+
         $balancing
             ->addOption(new Option(['hostname' => 'worker-1', 'isOnline' => true, 'cpu' => 80]))
             ->addOption(new Option(['hostname' => 'worker-2', 'isOnline' => false, 'cpu' => 20]))
@@ -53,6 +55,9 @@ class BalancingTest extends TestCase
 
         $option = $balancing->run() ?? new Option([]);
         $this->assertEquals('worker-4', $option->getState('hostname'));
+
+        $balancing = new Balancing(new Random());
+        $this->assertInstanceOf(Random::class, $balancing->getAlgo());
     }
 
     public function testAlgorithms(): void


### PR DESCRIPTION
`getAlgo` on `Balancing` class added. This is useful when working with utopia-php/framework, and separating logic into init/shutdown hooks. Being able to know the algo in different places of code allows a simpler codebase.

- [x] Implement new method
- [x] Add tests